### PR TITLE
deps: add custom tf-runner image

### DIFF
--- a/apps/tf-runner/Dockerfile
+++ b/apps/tf-runner/Dockerfile
@@ -1,0 +1,11 @@
+ARG VERSION=0.16.3
+FROM ghcr.io/flux-iac/tf-runner:v${VERSION}
+
+USER root
+
+RUN apk add --no-cache \
+    gcompat \
+    libc6-compat \
+    libstdc++
+
+USER 65532:65532

--- a/apps/tf-runner/ci/goss.yaml
+++ b/apps/tf-runner/ci/goss.yaml
@@ -1,0 +1,37 @@
+---
+package:
+  gcompat:
+    installed: true
+  libc6-compat:
+    installed: true
+  libstdc++:
+    installed: true
+
+file:
+  /lib/ld-linux-x86-64.so.2:
+    exists: true
+    filetype: file
+  /lib64/ld-linux-x86-64.so.2:
+    exists: true
+    filetype: symlink
+
+command:
+  onepassword-provider-loader:
+    exec: |-
+      set -eu
+      tmpdir="$(mktemp -d)"
+      cd "$tmpdir"
+      cat > main.tf <<'EOF'
+      terraform {
+        required_providers {
+          onepassword = {
+            source  = "1Password/onepassword"
+            version = "3.3.1"
+          }
+        }
+      }
+      EOF
+      tofu init -backend=false -input=false >/dev/null
+      .terraform/providers/registry.opentofu.org/1password/onepassword/3.3.1/linux_amd64/terraform-provider-onepassword_v3.3.1 2>&1 | grep -q 'This binary is a plugin'
+    exit-status: 0
+    timeout: 60000

--- a/apps/tf-runner/ci/latest.sh
+++ b/apps/tf-runner/ci/latest.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eu
+
+case "${1:-stable}" in
+  stable)
+    echo "0.16.3"
+    ;;
+  *)
+    echo "unsupported channel: ${1}" >&2
+    exit 1
+    ;;
+esac

--- a/apps/tf-runner/metadata.yaml
+++ b/apps/tf-runner/metadata.yaml
@@ -1,0 +1,11 @@
+---
+app: tf-runner
+base: false
+semantic_versioning: true
+channels:
+  - name: stable
+    platforms: ["linux/amd64"]
+    stable: true
+    tests:
+      enabled: true
+      type: cli


### PR DESCRIPTION
## Summary
- add a custom tf-runner image based on ghcr.io/flux-iac/tf-runner:v0.16.3
- install glibc compatibility packages required by dynamically linked Terraform providers like 1Password
- add CI metadata and a Goss test for the provider loader path

## Verification
- docker build --build-arg VERSION=0.16.3 -t ghcr.io/otosky/tf-runner:zztesting -f apps/tf-runner/Dockerfile .
- docker run verified the 1Password provider binary can start in the custom runner image
- prepare-matrices.py generated the tf-runner matrix via nix-shell

<!-- branch-stack-start -->

<!-- branch-stack-end -->
