### PR TITLE
fix: support tf-runner image tests

### DIFF
--- a/apps/tf-runner/Dockerfile
+++ b/apps/tf-runner/Dockerfile
@@ -8,4 +8,9 @@ RUN apk add --no-cache \
     libc6-compat \
     libstdc++
 
+COPY apps/tf-runner/entrypoint.sh /usr/local/bin/tf-runner-entrypoint
+RUN chmod +x /usr/local/bin/tf-runner-entrypoint
+
 USER 65532:65532
+
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/tf-runner-entrypoint"]

--- a/apps/tf-runner/entrypoint.sh
+++ b/apps/tf-runner/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "$#" -gt 0 ] && command -v "$1" >/dev/null 2>&1; then
+  exec "$@"
+fi
+
+exec tf-runner "$@"


### PR DESCRIPTION
## Summary
- keep Goss tests enabled for the custom tf-runner image
- add an entrypoint wrapper that runs normal commands for CI tests and falls back to tf-runner for production use

## Verification
- docker build --build-arg VERSION=0.16.3 -t ghcr.io/otosky/tf-runner:zztesting -f apps/tf-runner/Dockerfile .
- docker run ghcr.io/otosky/tf-runner:zztesting --help invokes tf-runner
- docker run ghcr.io/otosky/tf-runner:zztesting sh -c ... verifies the 1Password provider binary can start
- prepare-matrices.py confirms tf-runner tests_enabled=true